### PR TITLE
Fix problem with js strict mode.

### DIFF
--- a/kit/mangopay-kit.js
+++ b/kit/mangopay-kit.js
@@ -463,7 +463,7 @@ var mangoPay = {
 
             // Put together input data as string
             var parameters = "";
-            for (key in settings.data) {
+            for (var key in settings.data) {
                 parameters += (parameters.length > 0 ? '&' : '') + key + "=" + encodeURIComponent(settings.data[key]);
             }
 


### PR DESCRIPTION
We're using this library by requiring it with Webpack. It seems that webpack enables [javascript strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode), which does not like iterators defined without `var`, leading to this error:

`Uncaught ReferenceError: key is not defined`

More info about why to use `var` for iterators [here](http://stackoverflow.com/questions/5717126/var-or-no-var-in-javascripts-for-in-loop).

This PR just changes that to make sure you can use the card registration kit with strict mode enabled.