### PR TITLE
add package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "mangopay-cardregistration-js-kit",
+  "version": "0.0.0",
+  "description": "MangoPay CardRegistration JavaScript Kit is a client library designed to take care of the card registration process.",
+  "main": "kit/mangopay-kit.min.js",
+  "directories": {
+    "lib": "kit",
+    "example": "demo",
+    "test": "tests"
+  },
+  "files": [
+    "kit"
+  ],
+  "scripts": {
+    "test": "node -e \"console.log('Open in your browser ./tests/index.html')\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mangopay/cardregistration-js-kit.git"
+  },
+  "keywords": [
+    "mangopay",
+    "card",
+    "registration"
+  ],
+  "author": "MANGOPAY <support@mangopay.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Mangopay/cardregistration-js-kit/issues"
+  },
+  "homepage": "https://github.com/Mangopay/cardregistration-js-kit#readme"
+}
+


### PR DESCRIPTION
You don't have to publish on npm to at least allow npm users to directly install from github (even if it's better to be on npm). But that can be done later.

example dependency after this is merged:
```json
"mangopay-cardregistration-js-kit": "Mangopay/cardregistration-js-kit#4e0110eca964c3437bdaceacf50acdda274ca920",
```